### PR TITLE
modify config files to disable socket listening

### DIFF
--- a/push-down-test/config/no_push_down/tidb.toml
+++ b/push-down-test/config/no_push_down/tidb.toml
@@ -1,5 +1,6 @@
 port = 4005
 store = "mocktikv"
+socket = ""
 
 [status]
 report-status = false

--- a/push-down-test/config/with_push_down/tidb.toml
+++ b/push-down-test/config/with_push_down/tidb.toml
@@ -1,6 +1,7 @@
 port = 4007
 store = "tikv"
 path = "127.0.0.1:4479"
+socket = ""
 
 [status]
 report-status = false


### PR DESCRIPTION
In https://github.com/pingcap/tidb/pull/28486 tidb enabled socket file listening by default. This is part of this proposal: https://github.com/pingcap/tidb/blob/master/docs/design/2021-09-29-secure-bootstrap.md

**Note:** the insecure bootstrap remains the default, but to support the secure bootstrap, the server now listens on a socket file as well.

This modifies the configs to restore the previous behavior (no socket file). This is requires to prevent conflicts when tests are run.